### PR TITLE
Add version info and fix CLI imports

### DIFF
--- a/files/quantum_analyzer/__init__.py
+++ b/files/quantum_analyzer/__init__.py
@@ -1,0 +1,3 @@
+"""Quantum Analyzer package initialization."""
+
+__version__ = "0.1.0"

--- a/files/quantum_analyzer/analyzer.py
+++ b/files/quantum_analyzer/analyzer.py
@@ -1,0 +1,13 @@
+"""Wrapper module exposing ProjectAnalyzer and PatternLoader."""
+
+from importlib import util
+from pathlib import Path
+
+# Load the implementation from the top-level quantum_analyzer.py file
+_impl_path = Path(__file__).resolve().parent.parent / "quantum_analyzer.py"
+_spec = util.spec_from_file_location("_qa_impl", _impl_path)
+_module = util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+ProjectAnalyzer = _module.ProjectAnalyzer
+PatternLoader = _module.PatternLoader

--- a/files/quantum_analyzer/cli.py
+++ b/files/quantum_analyzer/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .analyzer import ProjectAnalyzer, PatternLoader
+from . import __version__
 from .config import load_config, merge_with_args, Severity, OutputFormat
 from .fix import apply_fixes
 
@@ -91,7 +92,7 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
 def main() -> int:
     """Main entry point."""
     # Print banner
-    print(f"Quantum Analyzer v{__import__('quantum_analyzer').__version__}")
+    print(f"Quantum Analyzer v{__version__}")
     print(f"Started at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     print("-" * 60)
     


### PR DESCRIPTION
## Summary
- add package `__init__` with `__version__`
- expose analysis classes via a wrapper module
- use package version in the CLI banner

## Testing
- `python -m py_compile files/quantum_analyzer/__init__.py files/quantum_analyzer/analyzer.py files/quantum_analyzer/cli.py`