### PR TITLE
Fix docs install command

### DIFF
--- a/files/docs/index.md
+++ b/files/docs/index.md
@@ -19,3 +19,4 @@ A modular, extensible code analysis toolkit that scans Python codebases and sugg
 
 ```bash
 pip install quantum-analyzer
+```


### PR DESCRIPTION
## Summary
- fix the quantum analyzer installation example and close the fenced code block in `index.md`

## Testing
- `pytest -q` *(fails: No module named pytest)*